### PR TITLE
Remove branch reference for `OpenAstronomy/azure-pipeline-templates`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,6 @@ resources:
     type: github
     endpoint: OpenAstronomy
     name: OpenAstronomy/azure-pipelines-templates
-    ref: master
 
 trigger:
   branches:


### PR DESCRIPTION
Hello, I'm one of the maintainers of https://github.com/OpenAstronomy/azure-pipelines-templates, which your repository references in `azure-pipelines.yml`. 

The name of the default branch of the azure-pipelines-templates repository may change in the future. Therefore, specifying the ref property for the OpenAstronomy repository is not recommended. [Azure Pipelines will use the current default branch when a ref is not specified.](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checking-out-a-specific-ref) For more information on loading the OpenAstronomy template please see [the documentation](https://openastronomy-azure-pipelines.readthedocs.io/en/latest/common.html).

As the `azure-pipelines.yml` file in your repository's default branch was referencing a specific branch on the `OpenAstronomy/azure-pipeline-templates` repository, we have opened this PR to remove the ref.

Please let me know if you have any questions.